### PR TITLE
Draft of backfilling delta

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+elifePipeline {
+    stage 'Checkout'
+    checkout scm
+    def commit = elifeGitRevision()
+ 
+    stage 'Delta Lax backfill'
+    lock('lax--prod') {
+        // TODO: retrieve last commit, empty string is good
+        def delta = sh(script: "./delta.sh ${commit}", returnStdout: true).trim()
+        if (delta) {
+            builderCmd "${delta}", 'lax--prod'
+            // TODO: store $commit as the last commit
+        }
+    }
+}

--- a/delta.sh
+++ b/delta.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# default to the first commit in the repository
+commit=${1:-8c3981d2f5b9348c7ab5842ecb0420126c779739}
+
+git diff --name-only $commit...HEAD articles


### PR DESCRIPTION
This build will trigger at each new commit cause by bot-lax-adaptor.

Goal: take the delta of articles and backfill them into Lax to keep its article-json (official source) updated.

Unclear yet where to store the last commit of this repository that has been backfilled there. Retrieving with SSH from Lax is a mess because builder/Fabric decorate the output, and in the case of multiple EC2 instance is ill-defined.

Possibilities:
- Lax private API
- storing it in this repo, it will trigger a new build but that build
will stop immediately with nothing to do because there are no modified
articles.
- some other data store